### PR TITLE
merge-upstream workflow to create PRs with latest changes from upstream

### DIFF
--- a/.github/workflows/merge-upstream.yml
+++ b/.github/workflows/merge-upstream.yml
@@ -13,9 +13,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.SURF_BOT_PAT }}
       - uses: fopina/upstream-to-pr@v1
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.SURF_BOT_PAT }}
           upstream-repository: https://github.com/projectdiscovery/httpx
           upstream-tag: 'v\d+\.\d+\.\d+'

--- a/.github/workflows/merge-upstream.yml
+++ b/.github/workflows/merge-upstream.yml
@@ -1,0 +1,21 @@
+name: auto update
+
+on:
+  schedule:
+    - cron: "0 12 * * *"
+  workflow_dispatch:
+    inputs: {}
+
+jobs:
+  autoupdate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PAT }}
+      - uses: fopina/upstream-to-pr@v1
+        with:
+          token: ${{ secrets.PAT }}
+          upstream-repository: https://github.com/projectdiscovery/httpx
+          upstream-tag: 'v\d+\.\d+\.\d+'


### PR DESCRIPTION
Workflow to open pull requests with latest changes from projectdiscovery/httpx to keep this fork up-to-date.

This requires a PAT that is able to open PRs as `GITHUB_TOKEN` will get blocked due to not being able to trigger PR workflows - even if permission to create PRs is added, it can never trigger workflows.

This closes #27

