### PR TITLE
cleanup unwanted differences from upstream

### DIFF
--- a/common/httpx/option.go
+++ b/common/httpx/option.go
@@ -61,7 +61,7 @@ var DefaultOptions = Options{
 	VHostIgnoreNumberOfLines: false,
 	VHostStripHTML:           false,
 	VHostSimilarityRatio:     85,
-	DefaultUserAgent:         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36 ppbsecurity/httpx",
+	DefaultUserAgent:         "httpx - Open-source project (github.com/projectdiscovery/httpx)",
 }
 
 func (options *Options) parseCustomCookies() {

--- a/runner/options.go
+++ b/runner/options.go
@@ -356,7 +356,7 @@ func ParseOptions() *Options {
 	)
 
 	flagSet.CreateGroup("output", "Output",
-		flagSet.StringVarP(&options.Output, "", "output", "", "file to write output results"),
+		flagSet.StringVarP(&options.Output, "output", "o", "", "file to write output results"),
 		flagSet.BoolVarP(&options.StoreResponse, "store-response", "sr", false, "store http response to output directory"),
 		flagSet.StringVarP(&options.StoreResponseDir, "store-response-dir", "srd", "", "store http response to custom directory"),
 		flagSet.BoolVar(&options.CSVOutput, "csv", false, "store output in csv format"),


### PR DESCRIPTION
Use #34 to compare our fork with upstream and removed the changes that are not required.

Keeping it cleaner to be able to (cleanup and) push some of the changes upstream in the future.