### PR TITLE
allow goreleaser to set override version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cmd/functional-test/httpx_dev
 cmd/functional-test/functional-test
 cmd/functional-test/httpx
 cmd/functional-test/*.cfg
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ builds:
     - darwin
   goarch:
     - amd64
-    - 386
+    - '386'
     - arm
     - arm64
 
@@ -25,6 +25,8 @@ builds:
 
   binary: '{{ .ProjectName }}'
   main: cmd/httpx/httpx.go
+
+  ldflags: '-s -w -X github.com/projectdiscovery/httpx/runner.version={{.Version}}'
 
 archives:
 - format: zip

--- a/runner/banner.go
+++ b/runner/banner.go
@@ -1,10 +1,9 @@
 package runner
 
 import (
-    "github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/gologger"
 	updateutils "github.com/projectdiscovery/utils/update"
 )
-
 
 const banner = `
     __    __  __       _  __
@@ -16,7 +15,7 @@ const banner = `
 `
 
 // Version is the current version of httpx
-const version = `v1.2.9-ppb`
+var version = `v1.2.9`
 
 // showBanner is used to show the banner to the user
 func showBanner() {


### PR DESCRIPTION
This way we can also keep version (in code) same as upstream and just use `-ppb` suffix when tagging releases